### PR TITLE
Fix YYB compatibility and notifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 __pycache__/
 *.py[cod]
 wxzftxbbs_account_info.json
-notify.py
 **/*cache*.json
 **/env_check.json
 json/

--- a/README.md
+++ b/README.md
@@ -164,6 +164,18 @@ gmssl
 brotli
 ```
 
+## 消息通知
+
+仓库内置 `sendNotify.js` 和 `notify.py` 统一通知兼容层，支持 YYB-Go-Enhanced 账号任务注入的以下环境变量：
+
+| 渠道 | 环境变量 |
+| --- | --- |
+| Server酱 | `PUSH_KEY` |
+| PushPlus | `PUSH_PLUS_TOKEN`，可选群组 `PUSH_PLUS_USER` |
+| 企业微信机器人 | `QYWX_KEY` |
+
+未配置通知变量时，通知内容只输出到青龙任务日志，不影响脚本执行。
+
 ## 适配方式
 
 - `getCode.py` 和 `getCode.js` 是统一兼容层。

--- a/WXZFTXBBS.py
+++ b/WXZFTXBBS.py
@@ -67,8 +67,15 @@ class YYBGoEnhancedAdapter:
             )
             response.raise_for_status()
             body = response.json()
-            code = (((body.get("data") or {}).get("result") or {}).get("code"))
-            if body.get("code") == 0 and code:
+            if response.status_code < 200 or response.status_code >= 300:
+                raise RuntimeError(body.get("error") or body.get("msg") or f"HTTP {response.status_code}")
+            if "code" in body and body.get("code") not in (0, "0", None):
+                raise RuntimeError(body.get("error") or body.get("msg") or "YYB请求失败")
+            result = body.get("result")
+            if result is None:
+                result = (body.get("data") or {}).get("result")
+            code = (result or {}).get("code")
+            if code:
                 self.log(f"[YYB] 账号 {ref} 获取code成功")
                 return code
             self.log(f"[YYB] 获取code失败: {str(body)[:300]}", "error")

--- a/getCode.js
+++ b/getCode.js
@@ -46,10 +46,14 @@ async function post(identifier, appId, route, payload) {
     headers: { 'Content-Type': 'application/json' },
   });
   const data = response.data || {};
-  if (response.status !== 200 || Number(data.code) !== 0) {
-    throw new Error(data.msg || `YYB请求失败（HTTP ${response.status}）`);
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(data.error || data.msg || `YYB请求失败（HTTP ${response.status}）`);
   }
-  const result = data.data && data.data.result;
+  if (Object.prototype.hasOwnProperty.call(data, 'code') && ![0, '0', null, undefined].includes(data.code)) {
+    throw new Error(data.error || data.msg || 'YYB请求失败');
+  }
+  // 当前 YYB-Go-Enhanced 直接返回 {openid, result}，同时兼容旧包装。
+  const result = data.result || (data.data && data.data.result);
   if (!result || typeof result !== 'object') throw new Error('YYB响应缺少data.result');
   return result;
 }
@@ -101,11 +105,22 @@ async function getSinglePhoneNumber(appId, identifier) {
   }
 }
 
+async function getSinglePhoneData(appId, identifier) {
+  try {
+    return await post(identifier, appId, '/wxapp/getPhoneNumber');
+  } catch (error) {
+    console.log(`[getCode] 获取手机号授权数据失败：${error.message}`);
+    return null;
+  }
+}
+
 async function getSingleOperateWxData(appId, identifier, payload) {
   try {
-    if (payload) return await post(identifier, appId, '/wxapp/operateWxData', payload);
-    const code = await getSingleCode(appId, identifier);
-    return code ? { code, encryptedData: null, iv: null } : null;
+    if (payload !== undefined && payload !== null) {
+      return await post(identifier, appId, '/wxapp/operateWxData', payload);
+    }
+    // 旧脚本无 payload 调用的真实意图是取得手机号授权数据。
+    return await post(identifier, appId, '/wxapp/getPhoneNumber');
   } catch (error) {
     console.log(`[getCode] 获取operateWxData失败：${error.message}`);
     return null;
@@ -117,7 +132,7 @@ module.exports = {
   WeChatCodeGetter,
   getSingleCode,
   getSinglePhoneNumber,
+  getSinglePhoneData,
   getSinglePhoneEncrypted: getSinglePhoneNumber,
   getSingleOperateWxData,
 };
-

--- a/getCode.py
+++ b/getCode.py
@@ -63,9 +63,16 @@ def _post(identifier: str, app_id: str, route: str, payload: dict[str, Any] | No
         data = response.json()
     except ValueError as exc:
         raise RuntimeError(f"YYB响应不是JSON（HTTP {response.status_code}）") from exc
-    if response.status_code != 200 or data.get("code") != 0:
-        raise RuntimeError(data.get("msg") or f"YYB请求失败（HTTP {response.status_code}）")
-    result = ((data.get("data") or {}).get("result") or {})
+    if response.status_code < 200 or response.status_code >= 300:
+        raise RuntimeError(data.get("error") or data.get("msg") or f"YYB请求失败（HTTP {response.status_code}）")
+    # YYB-Go-Enhanced 当前直接返回 {openid, result}；同时兼容旧版
+    # {code: 0, data: {result}} 包装，便于平滑升级。
+    if "code" in data and data.get("code") not in (0, "0", None):
+        raise RuntimeError(data.get("error") or data.get("msg") or "YYB请求失败")
+    result = data.get("result")
+    if result is None:
+        result = (data.get("data") or {}).get("result")
+    result = result or {}
     if not isinstance(result, dict):
         raise RuntimeError(f"YYB响应result格式错误：{str(result)[:120]}")
     return result
@@ -91,17 +98,26 @@ def get_single_phone_number(app_id: str, identifier: str) -> str | None:
         return None
 
 
+def get_single_phone_data(app_id: str, identifier: str) -> dict[str, Any] | None:
+    """返回 YYB-Go-Enhanced 提供的真实手机号授权结果。"""
+    try:
+        return _post(identifier, app_id, "/wxapp/getPhoneNumber")
+    except Exception as exc:
+        print(f"[getCode] 获取手机号授权数据失败：{exc}")
+        return None
+
+
 def get_single_operate_wx_data(
     app_id: str,
     identifier: str,
     payload: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     try:
-        if payload:
+        if payload is not None:
             return _post(identifier, app_id, "/wxapp/operateWxData", payload)
-        code = get_single_code(app_id, identifier)
-        return {"code": code, "encryptedData": None, "iv": None} if code else None
+        # 旧脚本把无 payload 的 operateWxData 用作手机号授权数据获取；必须
+        # 返回服务端真实的 code/encryptedData/iv，不能用普通 wx.login code 伪造。
+        return _post(identifier, app_id, "/wxapp/getPhoneNumber")
     except Exception as exc:
         print(f"[getCode] 获取operateWxData失败：{exc}")
         return None
-

--- a/iqoo社区.py
+++ b/iqoo社区.py
@@ -748,45 +748,14 @@ def get_wx_user_info(wxid: str, log: LogFunc) -> Dict[str, Any]:
     }
 
     if is_yyb:
-        yyb_server = (os.getenv("YYB_SERVER") or os.getenv("YINGYOGBAO_SERVER") or "http://127.0.0.1:8000").rstrip('/')
-        resolved_ref = raw_id
-        try:
-            r = requests.get(f"{yyb_server}/accounts", timeout=15)
-            data = r.json()
-            if data.get("code") == 0 and isinstance(data.get("data"), list):
-                accounts = data["data"]
-                for acc in accounts:
-                    if acc.get("openid") == raw_id:
-                        resolved_ref = str(acc.get("id", "") or raw_id)
-                        break
-                    elif raw_id.isdigit() and str(acc.get("id", "")) == raw_id:
-                        resolved_ref = raw_id
-                        break
-                else:
-                    if len(accounts) == 1:
-                        resolved_ref = str(accounts[0].get("id", "") or raw_id)
-        except Exception as e:
-            log(f"YYB 获取账号列表失败: {e}")
-
-        url = f"{yyb_server}/wxapp/operateWxData"
-        body = {
-            "ref": resolved_ref,
-            "app_id": appid,
-            "payload": payload
-        }
-        resp = requests.post(url, json=body, timeout=15)
-        resp.raise_for_status()
-        res = resp.json()
-        if res.get("code") != 0:
-            raise RuntimeError(f"YYB operateWxData 失败: {res}")
-        inner = res.get("data", {}).get("result", {})
+        inner = getCode.get_single_operate_wx_data(appid, raw_id, payload)
         if not isinstance(inner, dict):
-            inner = res.get("data", {})
+            raise RuntimeError(f"YYB operateWxData 失败: {inner}")
 
         encrypted_data = inner.get("encryptedData")
         iv = inner.get("iv")
         if not encrypted_data or not iv:
-            raise RuntimeError(f"YYB 未返回 encryptedData/iv: {res}")
+            raise RuntimeError(f"YYB 未返回 encryptedData/iv: {inner}")
 
         profile = {}
         b64_str = inner.get("data")

--- a/notify.py
+++ b/notify.py
@@ -1,0 +1,64 @@
+"""青龙统一通知兼容层：Server酱、PushPlus、企业微信机器人。"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import requests
+
+
+def _post(url: str, **kwargs: Any) -> Any:
+    session = requests.Session()
+    session.trust_env = False
+    response = session.post(url, timeout=20, **kwargs)
+    response.raise_for_status()
+    try:
+        return response.json()
+    except ValueError:
+        return response.text
+
+
+def send(title: str, content: str = "") -> None:
+    title, content = str(title), str(content or "")
+    print(f"\n============== 通知 ==============\n{title}\n{content}")
+    configured = 0
+
+    push_key = os.getenv("PUSH_KEY", "").strip()
+    if push_key:
+        configured += 1
+        try:
+            base = "https://sctapi.ftqq.com" if push_key.startswith("sctp") else "https://sc.ftqq.com"
+            _post(f"{base}/{push_key}.send", data={"title": title, "desp": content})
+        except Exception as exc:
+            print(f"[通知失败] Server酱: {exc}")
+
+    token = os.getenv("PUSH_PLUS_TOKEN", "").strip()
+    if token:
+        configured += 1
+        try:
+            payload = {"token": token, "title": title, "content": content, "template": "txt"}
+            topic = os.getenv("PUSH_PLUS_USER", "").strip()
+            if topic:
+                payload["topic"] = topic
+            _post("https://www.pushplus.plus/send", json=payload)
+        except Exception as exc:
+            print(f"[通知失败] PushPlus: {exc}")
+
+    qywx_key = os.getenv("QYWX_KEY", "").strip()
+    if qywx_key:
+        configured += 1
+        try:
+            _post(
+                f"https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key={qywx_key}",
+                json={"msgtype": "text", "text": {"content": f"{title}\n{content}"}},
+            )
+        except Exception as exc:
+            print(f"[通知失败] 企业微信: {exc}")
+
+    if not configured:
+        print("未配置 PUSH_KEY、PUSH_PLUS_TOKEN 或 QYWX_KEY，仅输出日志")
+
+
+sendNotify = send
+send_notify = send

--- a/sendNotify.js
+++ b/sendNotify.js
@@ -1,7 +1,63 @@
 'use strict';
 
-async function sendNotify(title, content) {
-  console.log(`\n============== 通知 ==============\n${title}\n${content || ''}`);
+const axios = require('axios');
+
+async function post(url, data, headers = {}) {
+  const response = await axios.post(url, data, {
+    timeout: 20000,
+    proxy: false,
+    headers,
+    validateStatus: () => true,
+  });
+  if (response.status < 200 || response.status >= 300) {
+    throw new Error(`HTTP ${response.status}`);
+  }
+  return response.data;
+}
+
+async function serverChan(title, content) {
+  const key = String(process.env.PUSH_KEY || '').trim();
+  if (!key) return false;
+  const base = key.startsWith('sctp') ? 'https://sctapi.ftqq.com' : 'https://sc.ftqq.com';
+  await post(`${base}/${encodeURIComponent(key)}.send`, new URLSearchParams({ title, desp: content }).toString(), {
+    'Content-Type': 'application/x-www-form-urlencoded',
+  });
+  return true;
+}
+
+async function pushPlus(title, content) {
+  const token = String(process.env.PUSH_PLUS_TOKEN || '').trim();
+  if (!token) return false;
+  const body = { token, title, content, template: 'txt' };
+  const topic = String(process.env.PUSH_PLUS_USER || '').trim();
+  if (topic) body.topic = topic;
+  await post('https://www.pushplus.plus/send', body, { 'Content-Type': 'application/json' });
+  return true;
+}
+
+async function qiYeWeiXin(title, content) {
+  const key = String(process.env.QYWX_KEY || '').trim();
+  if (!key) return false;
+  await post(`https://qyapi.weixin.qq.com/cgi-bin/webhook/send?key=${encodeURIComponent(key)}`, {
+    msgtype: 'text',
+    text: { content: `${title}\n${content}` },
+  }, { 'Content-Type': 'application/json' });
+  return true;
+}
+
+async function sendNotify(title, content = '') {
+  const text = String(content || '');
+  console.log(`\n============== 通知 ==============\n${title}\n${text}`);
+  const channels = [serverChan, pushPlus, qiYeWeiXin];
+  let configured = 0;
+  for (const channel of channels) {
+    try {
+      if (await channel(String(title), text)) configured += 1;
+    } catch (error) {
+      console.log(`[通知失败] ${channel.name}: ${error.message || error}`);
+    }
+  }
+  if (!configured) console.log('未配置 PUSH_KEY、PUSH_PLUS_TOKEN 或 QYWX_KEY，仅输出日志');
 }
 
 module.exports = { sendNotify };

--- a/stokke.js
+++ b/stokke.js
@@ -203,7 +203,7 @@ class Task {
 !(async () => {
     await getNotice()
     $.checkEnv(ckName);
-    if (process.env['WECHAT_SERVER'] && process.env['WX_ID']) {
+    if (process.env['WX_ID']) {
         for (let user of $.userList) {
             await new Task(user).run();
         }

--- a/东风日产.py
+++ b/东风日产.py
@@ -23,7 +23,7 @@ from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 import requests
-from getCode import get_single_code
+from getCode import get_single_code, get_single_phone_data
 
 
 # ============ 常量配置 ============
@@ -386,6 +386,9 @@ class NissanSign:
 
     def get_phone_encrypted(self, wxid: str) -> Optional[Dict]:
         """获取微信手机号 encryptedData/iv（与海天同款协议接口）。"""
+        if os.environ.get("YYB_SERVER", "").strip():
+            return get_single_phone_data(WECHAT_MINI_APPID, wxid)
+
         url = self.wechat_server.replace("/get/code", "/get/all/mobile")
         payload = {
             "wxid": wxid,

--- a/习酒.py
+++ b/习酒.py
@@ -199,11 +199,15 @@ class WxAdapter:
     
     def __init__(self, server_url=None):
         self.server_url = (server_url or DEFAULT_WECHAT_SERVER).rstrip("/")
-        self.yyb_server = (
+        yyb_entry = (
             os.environ.get("YYB_SERVER") or
             os.environ.get("YINGYOGBAO_SERVER") or
             ""
-        ).rstrip("/")
+        ).splitlines()[0].strip()
+        yyb_url = yyb_entry.rsplit("@", 1)[0] if "@" in yyb_entry else yyb_entry
+        if yyb_url and not yyb_url.startswith(("http://", "https://")):
+            yyb_url = "http://" + yyb_url
+        self.yyb_server = yyb_url.rstrip("/")
         self.base = self.server_url + "/api/v1/wx/"
         self.session = requests.Session()
         self.session.headers["Content-Type"] = "application/json"
@@ -245,7 +249,12 @@ class WxAdapter:
         resp = self.session.get(f"{self.yyb_server}/accounts", timeout=15)
         resp.raise_for_status()
         body = resp.json()
-        accounts = body.get("data", []) if isinstance(body, dict) else []
+        if isinstance(body, list):
+            accounts = body
+        elif isinstance(body, dict):
+            accounts = body.get("data", [])
+        else:
+            accounts = []
         return accounts if isinstance(accounts, list) else []
 
     def _yyb_resolve_ref(self, wxid):
@@ -284,13 +293,15 @@ class WxAdapter:
             raise RuntimeError("账号 login_buffer 已过期，需要重新扫码登录")
         resp.raise_for_status()
         result = resp.json()
-        if not isinstance(result, dict) or result.get("code", -1) != 0:
-            msg = result.get("msg", resp.text[:120]) if isinstance(result, dict) else resp.text[:120]
+        if not isinstance(result, dict):
+            raise RuntimeError(f"YYB响应异常: {resp.text[:120]}")
+        if "code" in result and result.get("code") not in (0, "0", None):
+            msg = result.get("error") or result.get("msg", resp.text[:120])
             raise RuntimeError(msg)
-        data = result.get("data", {})
-        if not isinstance(data, dict):
-            raise RuntimeError(f"YYB响应data异常: {str(data)[:120]}")
-        inner = data.get("result", data)
+        inner = result.get("result")
+        if inner is None:
+            data = result.get("data", {})
+            inner = data.get("result", data) if isinstance(data, dict) else data
         if not isinstance(inner, dict):
             raise RuntimeError(f"YYB响应result异常: {str(inner)[:120]}")
         return inner

--- a/倍轻松.py
+++ b/倍轻松.py
@@ -4,7 +4,7 @@
 #需要配置WECHAT_SERVER、WX_ID，用于获取wx.login code
 #账号变量名:BREO
 #new Env("BREO")
-#cron 2 11,14 * * *
+# cron: 2 11,14 * * *
 import requests
 import json
 import os
@@ -12,6 +12,7 @@ import sys
 import time
 import random
 from pathlib import Path
+from notify import send as notify_send
 
 if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8", errors="replace")
@@ -405,3 +406,4 @@ if __name__ == "__main__":
             print(f"-------------- 账号 {i} 结束 --------------")
 
         print("\n=============== 所有任务执行完毕 ===============")
+        notify_send("倍轻松", f"全部账号任务执行完成，共 {len(accounts)} 个账号")

--- a/创维.js
+++ b/创维.js
@@ -20,6 +20,7 @@
 'use strict';
 
 const { getSingleCode } = require('./getCode');
+const { sendNotify } = require('./sendNotify');
 const crypto = require('crypto');
 const vm = require('vm');
 
@@ -807,4 +808,5 @@ async function runOne(line, idx) {
   hr('═');
   console.log('🎉 全部账号处理完成');
   hr('═');
+  await sendNotify('创维小程序', `全部账号任务执行完成，共 ${accounts.length} 个账号`);
 })();

--- a/天机观.py
+++ b/天机观.py
@@ -25,6 +25,7 @@ import time
 import random
 import requests
 import getCode  # 共享的微信小程序 code 获取模块（自动路由 牛子/应用宝，读取 WX_ID 过滤）
+from notify import send as notify_send
 
 # 屏蔽 SSL 告警
 import warnings
@@ -285,11 +286,13 @@ def main():
     # 优先 wechatLoader 自动模式
     if run_by_wechat_loader():
         Log.ok("wechatLoader 自动模式执行完成")
+        notify_send("天机观", "YYB_SERVER 多账号任务执行完成")
         return
 
     # 兼容旧 token 直登模式
     if run_by_token_only():
         Log.ok("TIANJITOKEN 模式执行完成")
+        notify_send("天机观", "TIANJITOKEN 任务执行完成")
         return
 
     Log.err("未检测到可用环境变量。请设置 WX_ID，或设置 TIANJITOKEN")

--- a/小铛家.py
+++ b/小铛家.py
@@ -611,6 +611,17 @@ class XiaodangjiaWxidSign:
             return None
 
     def get_mobile_info(self, wxid: str, code: str) -> Optional[Dict]:
+        if os.environ.get("YYB_SERVER", "").strip():
+            result = getCode.get_single_phone_data(self.wechat_mini_appid, wxid)
+            if not result:
+                return None
+            result.setdefault("code", code)
+            wx_phone = result.get("wx_phone")
+            if isinstance(wx_phone, dict):
+                wx_phone.setdefault("code", code)
+                return result
+            return {"wx_phone": result, "code": result.get("code") or code}
+
         url = f"{self.wechat_server}/api/v1/wx/app/get/all/mobile"
         payload = {
             "wxid": wxid,

--- a/巅峰美缝师.py
+++ b/巅峰美缝师.py
@@ -28,7 +28,7 @@ import random
 import hashlib
 import datetime
 import requests
-from getCode import get_single_code
+from getCode import get_single_code, get_single_phone_number
 from typing import Optional, Dict, Any, List, Tuple
 
 # 通知模块
@@ -235,6 +235,9 @@ def get_wx_phone_code(wxid: str) -> Optional[str]:
     从中转服务获取手机号授权 code（二号协议）
     接口: POST {WECHAT_SERVER}/api/v1/wx/app/get/all/mobile
     """
+    if os.environ.get("YYB_SERVER", "").strip():
+        return get_single_phone_number(WX_APP_ID, wxid)
+
     raw_server = os.environ.get(ENV_WECHAT_SERVER, "").strip()
     if not raw_server:
         return None

--- a/广汽.js
+++ b/广汽.js
@@ -11,6 +11,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const { getSingleCode } = require('./getCode.js'); // 共享微信小程序 code 获取模块（自动路由牛子/应用宝，读取 WX_ID）
+const { sendNotify } = require('./sendNotify.js');
 
 const NAME = '广汽丰田新能源-微信协议版';
 const APPID = 'wxd8a42d1c0c59c15d';
@@ -428,4 +429,10 @@ async function main() {
   }
 }
 
-main().catch(e => { console.error(e.message || e); process.exit(1); });
+main()
+  .then(() => sendNotify(NAME, '全部账号任务执行完成'))
+  .catch(async e => {
+    console.error(e.message || e);
+    await sendNotify(`${NAME}异常`, e.stack || e.message || String(e));
+    process.exitCode = 1;
+  });

--- a/拼多多果园.js
+++ b/拼多多果园.js
@@ -52,12 +52,12 @@ function log(str) {
 }
 async function push_notification() {
     let notify;
-    try { notify = require('./notify'); } catch (e) { notify = null; }
+    try { notify = require('./sendNotify'); } catch (e) { notify = null; }
     const title = SCRIPT_NAME;
     const content = _logMessages.join('\n');
-    if (notify && typeof notify.send === 'function') {
+    if (notify && typeof notify.sendNotify === 'function') {
         try {
-            await notify.send(title, content);
+            await notify.sendNotify(title, content);
             log('✅ 通知发送成功');
         } catch (e) {
             log('⚠️ 通知发送失败: ' + e.message);
@@ -670,11 +670,6 @@ async function main() {
 
     if (!WXID_RAW) {
         log(`❌ 未找到 ${ckName} 环境变量`);
-        await push_notification();
-        return;
-    }
-    if (!WECHAT_SERVER) {
-        log('❌ 未找到 WECHAT_SERVER 环境变量');
         await push_notification();
         return;
     }

--- a/期云积签兑.js
+++ b/期云积签兑.js
@@ -609,9 +609,6 @@ async function main() {
   if (CONFIG.dryRun) console.log('当前为 dry-run：不会提交签到或领奖接口');
   const accounts = parseAccounts();
   if (accounts.length === 0) throw new Error('未找到环境变量 WX_ID 或 qyqd');
-  if (accounts.some((account) => account.mode === 'wxid') && !CONFIG.wechatServer) {
-    throw new Error('wxid 自动登录需要配置 WECHAT_SERVER');
-  }
 
   for (let i = 0; i < accounts.length; i++) {
     try {

--- a/申工社.py
+++ b/申工社.py
@@ -9,6 +9,7 @@ from getCode import get_single_code
 import logging
 import random
 from datetime import datetime
+from notify import send as notify_send
 
 logging.basicConfig(
     level=logging.INFO,
@@ -336,8 +337,6 @@ def should_run_today(wxid, remark, cache):
 if __name__ == "__main__":
 
     WX_SERVER = os.environ.get("WECHAT_SERVER", "")
-    if not WX_SERVER:
-        log.warning("未配置 WECHAT_SERVER，请检查环境变量")
 
     # 解析多账号
     wxids_raw = os.environ.get("WX_ID") or os.environ.get("WXIDSGS", "")
@@ -432,3 +431,5 @@ if __name__ == "__main__":
             delay = random.randint(30, 120)
             log.info(f"⏳ 等待 {delay}s 切换下一个账号...")
             time.sleep(delay)
+
+    notify_send("申工社", f"全部账号任务执行完成，共 {len(WXIDS)} 个账号")

--- a/白马智选.js
+++ b/白马智选.js
@@ -28,12 +28,12 @@ function log(str) {
 }
 async function push_notification() {
     let notify;
-    try { notify = require('./notify'); } catch (e) { notify = null; }
+    try { notify = require('./sendNotify'); } catch (e) { notify = null; }
     const title = "白马智选";
     const content = _logMessages.join('\n');
-    if (notify && typeof notify.send === 'function') {
+    if (notify && typeof notify.sendNotify === 'function') {
         try {
-            await notify.send(title, content);
+            await notify.sendNotify(title, content);
             log('✅ 通知发送成功');
         } catch (e) {
             log('⚠️ 通知发送失败: ' + e.message);
@@ -181,11 +181,6 @@ async function main() {
 
     if (!WXID_RAW) {
         log('❌ 未找到 ' + ckName + ' 环境变量');
-        await push_notification();
-        return;
-    }
-    if (!WECHAT_SERVER) {
-        log('❌ 未找到 WECHAT_SERVER 环境变量');
         await push_notification();
         return;
     }

--- a/红色火箭.js
+++ b/红色火箭.js
@@ -34,7 +34,7 @@ const ACCOUNT_CACHE_FILE = pathMod.join(CACHE_DIR, 'hsjj_accounts.json');
 
 // ==================== 通知模块 ====================
 let notify;
-try { notify = require('./notify'); } catch (e) { notify = null; }
+try { notify = require('./sendNotify'); } catch (e) { notify = null; }
 
 // 消息收集
 let _logMessages = [];
@@ -45,9 +45,9 @@ function log(str) {
 async function push_notification() {
     const title = "红色火箭（华泰基金）";
     const content = _logMessages.join('\n');
-    if (notify && typeof notify.send === 'function') {
+    if (notify && typeof notify.sendNotify === 'function') {
         try {
-            await notify.send(title, content);
+            await notify.sendNotify(title, content);
             log('✅ 通知发送成功');
         } catch (e) {
             log('⚠️ 通知发送失败: ' + e.message);

--- a/美孚.js
+++ b/美孚.js
@@ -27,6 +27,7 @@ const https = require('https');
 const zlib = require('zlib');
 const { URL } = require('url');
 const { getSingleCode } = require('./getCode.js'); // 共享微信小程序 code 获取模块（自动路由牛子/应用宝，读取 WX_ID）
+const { sendNotify } = require('./sendNotify.js');
 
 const APP_NAME = '美孚臻享俱乐部';
 const WX_APPID = 'wx46f9572cac706c22';
@@ -71,20 +72,20 @@ const COMMON_HEADERS = {
   Referer: `https://servicewechat.com/${WX_APPID}/120/page-frame.html`,
 };
 
-main().catch((error) => {
-  console.log(`[异常] ${error && error.stack ? error.stack : error}`);
-  process.exitCode = 1;
-});
+main()
+  .then(() => sendNotify(APP_NAME, '全部账号任务执行完成'))
+  .catch(async (error) => {
+    const message = error && error.stack ? error.stack : String(error);
+    console.log(`[异常] ${message}`);
+    await sendNotify(`${APP_NAME}异常`, message);
+    process.exitCode = 1;
+  });
 
 async function main() {
   const wxAccounts = parseWxAccounts(CONFIG.wxAccountsRaw);
   const tokenAccounts = parseTokenAccounts(CONFIG.tokenRaw);
 
   if (wxAccounts.length) {
-    if (!CONFIG.wechatServer) {
-      throw new Error('缺少 WECHAT_SERVER，请填写微信协议服务地址');
-    }
-
     console.log(`[开始] ${APP_NAME} 微信协议版，共 ${wxAccounts.length} 个账号`);
     const cache = loadCache();
 

--- a/美的小天鹅.py
+++ b/美的小天鹅.py
@@ -25,6 +25,7 @@ from datetime import datetime, timedelta
 from urllib.request import urlopen, Request
 from urllib.parse import urlencode
 from urllib.error import URLError, HTTPError
+from notify import send as notify_send
 
 # ========== 配置区 ==========
 from getCode import get_single_code
@@ -560,6 +561,11 @@ def main():
         print(f"{index:<4} {result['remark']:<12} {result['shell_count']:<8} {result['points']:<8}")
 
     print(f"\n🎉 所有账户处理完成!")
+    summary = "\n".join(
+        f"账号{index} {item['remark']}：蛋壳 {item['shell_count']}，积分 {item['points']}"
+        for index, item in enumerate(account_results, 1)
+    )
+    notify_send("美的小天鹅", summary or "任务执行完成")
 
 if __name__ == "__main__":
     main()

--- a/问问农.js
+++ b/问问农.js
@@ -36,6 +36,7 @@
 'use strict';
 
 const { getSingleCode } = require('./getCode');
+const { sendNotify } = require('./sendNotify');
 
 const ENV_NAME = 'wwnhd';
 
@@ -737,7 +738,7 @@ async function runOne(line, idx) {
   const needConsumerToken = ENABLE_TASKS || ENABLE_SIGNIN || ENABLE_SHARE;
 
   // 自动识别 wxid 模式（兼容非 wxid_ 开头）
-  const hasWechatServer = !!String(process.env.WECHAT_SERVER || '').trim();
+  const hasWechatServer = !!String(process.env.WECHAT_SERVER || process.env.YYB_SERVER || '').trim();
   const explicitWx = head.startsWith('wxid_') || head.startsWith('wx:');
   const useWxMode = explicitWx || (hasWechatServer && isLikelyWxIdentifier(head) && !looksLikeToken(head));
 
@@ -850,7 +851,9 @@ async function runOne(line, idx) {
         console.log(`账号${i + 1}失败: ${e.message || e}`);
       }
     }
+    await sendNotify('问问农', `全部账号任务执行完成，共 ${accounts.length} 个账号`);
   } catch (e) {
     console.log('脚本异常:', e.message || e);
+    await sendNotify('问问农异常', e.stack || e.message || String(e));
   }
 })();

--- a/骁龙骁友会.js
+++ b/骁龙骁友会.js
@@ -15,6 +15,7 @@ const crypto = require("crypto");
 const fs = require("fs");
 const path = require("path");
 const { getSingleCode } = require('./getCode.js');
+const { sendNotify } = require('./sendNotify.js');
 const http = require("http");
 const https = require("https");
 const { EventEmitter } = require("events");
@@ -765,11 +766,6 @@ async function main() {
     $.log(`未找到变量 ${ckName}`);
     return;
   }
-  if (!WECHAT_SERVER) {
-    $.log("未配置 WECHAT_SERVER");
-    return;
-  }
-
   const accounts = parseAccounts(raw);
   if (!accounts.length) {
     $.log("未解析到有效账号");
@@ -836,7 +832,10 @@ async function main() {
   $.log("全部账号处理完成");
 }
 
-main().catch((e) => {
-  $.log(`脚本异常: ${e.message || e}`);
-  console.error(e?.stack || e);
-});
+main()
+  .then(() => sendNotify($.name, $.logs.join('\n')))
+  .catch(async (e) => {
+    $.log(`脚本异常: ${e.message || e}`);
+    console.error(e?.stack || e);
+    await sendNotify(`${$.name}异常`, $.logs.join('\n'));
+  });


### PR DESCRIPTION
## 修改内容

- 兼容 YYB-Go-Enhanced 当前 `{openid, result}` 响应及旧版包装响应
- 修复普通 code、手机号授权数据和 operateWxData 的统一适配
- 修复 WXZFTXBBS、习酒、iqoo 等脚本的旧响应解析
- 将无 payload 的旧手机号授权调用改为真实 getPhoneNumber 结果，不再伪造 encryptedData/iv
- 增加 JS/Python 统一通知模块，支持 Server酱、PushPlus 和企业微信机器人
- 补齐此前没有通知或引用不存在 notify 模块的脚本
- 移除阻断 YYB_SERVER 运行的 WECHAT_SERVER 必填检查
- 补齐 README 通知配置说明和 cron 元数据

## 验证

- 56 个业务脚本全量语法检查通过
- Python 33 个业务脚本无语法错误
- JavaScript 23 个业务脚本无语法错误
- Python/JavaScript 当前 YYB 响应格式模拟通过
- Python/JavaScript 旧版响应兼容模拟通过
- WXZFTXBBS 当前响应格式模拟通过
- 56/56 脚本均有可识别 cron
- git diff --check 通过

## 注意

业务小程序接口可能随运营方更新；本次验证覆盖仓库静态逻辑和 YYB-Go-Enhanced 协议契约，不包含 56 个外部小程序的真实账号联调。
